### PR TITLE
Enable Doze

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -218,4 +218,7 @@
         don't support RIL_REQUEST_GET_RADIO_CAPABILITY
         format is UMTS|LTE|... -->
    <string translatable="false" name="config_radio_access_family">GSM | WCDMA</string>
+   
+    <!-- Enable Doze Powersaving Mode as it is a major MM feature -->
+     <bool name="config_enableAutoPowerModes">true</bool>
 </resources>


### PR DESCRIPTION
this is set to false by default and needs to be turned on per device depending if the device supports SENSOR_TYPE_SIGNIFICANT_MOTION

I saw this when comparing aosp vs the factory image and as it is a major feature change in Marshmallow

details can be seen here  https://source.android.com/devices/tech/power/mgmt.html
